### PR TITLE
add support for automatic task provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+out
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Meson",
 	"description": "Meson langage support for Visual Studio Code",
 	"icon": "graphics/icon.png",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"license": "Apache",
 	"publisher": "asabil",
 	"author": {
@@ -18,12 +18,34 @@
 	},
 	"homepage": "https://github.com/asabil/vscode-meson/blob/master/README.md",
 	"engines": {
-		"vscode": "^1.12.0"
+		"vscode": "^1.26.0"
 	},
 	"categories": [
 		"Programming Languages"
 	],
+	"activationEvents": [
+		"onCommand:workbench.action.tasks.runTask"
+	],
+	"main": "./out/src/extension",
 	"contributes": {
+		"taskDefinitions": [
+			{
+				"type": "meson",
+				"required": [
+					"task"
+				],
+				"properties": {
+					"task": {
+						"type": "string",
+						"description": "The Meson task to customize"
+					},
+					"file": {
+						"type": "string",
+						"description": "The Meson file that provides the task. Can be omitted."
+					}
+				}
+			}
+		],
 		"languages": [
 			{
 				"id": "meson",
@@ -46,5 +68,16 @@
 				"path": "./syntaxes/meson.tmLanguage.json"
 			}
 		]
+	},
+	"scripts": {
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"devDependencies": {
+		"typescript": "^2.4.1",
+		"vscode": "^1.1.17",
+		"@types/node": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-    "name": "meson",
-    "displayName": "Meson",
-    "description": "Meson langage support for Visual Studio Code",
-    "icon": "graphics/icon.png",
-    "version": "1.1.0",
-    "license": "Apache",
-    "publisher": "asabil",
-    "author": {
-        "name": "Ali Sabil"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/asabil/vscode-meson.git"
-    },
-    "bugs": {
-        "url": "https://github.com/asabil/vscode-meson/issues"
-    },
-    "homepage": "https://github.com/asabil/vscode-meson/blob/master/README.md",
-    "engines": {
-        "vscode": "^1.12.0"
-    },
-    "categories": [
-        "Programming Languages"
-    ],
-    "contributes": {
-        "languages": [
-            {
-                "id": "meson",
-                "aliases": [
-                    "Meson",
-                    "meson",
-                    "mesonbuild"
-                ],
-                "filenames": [
-                    "meson.build",
-                    "meson_options.txt"
-                ],
-                "configuration": "./language-configuration.json"
-            }
-        ],
-        "grammars": [
-            {
-                "language": "meson",
-                "scopeName": "source.meson",
-                "path": "./syntaxes/meson.tmLanguage.json"
-            }
-        ]
-    }
+	"name": "meson",
+	"displayName": "Meson",
+	"description": "Meson langage support for Visual Studio Code",
+	"icon": "graphics/icon.png",
+	"version": "1.1.0",
+	"license": "Apache",
+	"publisher": "asabil",
+	"author": {
+		"name": "Ali Sabil"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/asabil/vscode-meson.git"
+	},
+	"bugs": {
+		"url": "https://github.com/asabil/vscode-meson/issues"
+	},
+	"homepage": "https://github.com/asabil/vscode-meson/blob/master/README.md",
+	"engines": {
+		"vscode": "^1.12.0"
+	},
+	"categories": [
+		"Programming Languages"
+	],
+	"contributes": {
+		"languages": [
+			{
+				"id": "meson",
+				"aliases": [
+					"Meson",
+					"meson",
+					"mesonbuild"
+				],
+				"filenames": [
+					"meson.build",
+					"meson_options.txt"
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "meson",
+				"scopeName": "source.meson",
+				"path": "./syntaxes/meson.tmLanguage.json"
+			}
+		]
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,35 @@
+'use strict';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getMesonTasks } from './tasks';
+
+let mesonTaskProvider: vscode.Disposable | undefined;
+
+export function activate(_context: vscode.ExtensionContext): void {
+	let workspaceRoot = vscode.workspace.rootPath;
+	if (!workspaceRoot) return;
+	
+	let pattern = path.join(workspaceRoot, 'meson.build');
+	let mesonPromise: Thenable<vscode.Task[]> | undefined = undefined;
+	let fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+	fileWatcher.onDidChange(() => mesonPromise = undefined);
+	fileWatcher.onDidCreate(() => mesonPromise = undefined);
+	fileWatcher.onDidDelete(() => mesonPromise = undefined);
+	mesonTaskProvider = vscode.tasks.registerTaskProvider('meson', {
+		provideTasks: () => {
+			if (!mesonPromise)
+				mesonPromise = getMesonTasks(workspaceRoot);
+			return mesonPromise;
+		},
+		resolveTask(_task: vscode.Task): vscode.Task | undefined {
+			return undefined;
+		}
+	});
+}
+
+export function deactivate(): void {
+	if (mesonTaskProvider) {
+		mesonTaskProvider.dispose();
+	}
+}

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,83 @@
+'use strict';
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { exists, exec } from './utils';
+
+interface MesonTaskDefinition extends vscode.TaskDefinition {
+	task: string;
+	file?: string;
+}
+
+export async function getMesonTasks(_dir: string): Promise<vscode.Task[]> {
+	let emptyTasks: vscode.Task[] = [];
+	if (!_dir) {
+		return emptyTasks;
+	}
+	let mesonFile = path.join(_dir, 'meson.build');
+	if (!await exists(mesonFile)) {
+		return emptyTasks;
+	}
+
+	let commandLine = 'meson . .meson';
+	try {
+		let { stdout, stderr } = await exec(commandLine, { cwd: _dir });
+		if (stderr && stderr.length > 0) {
+			getOutputChannel().appendLine(stderr);
+			getOutputChannel().show(true);
+		}
+		let result: vscode.Task[] = [];
+		if (stdout) {
+			let taskName = "build";
+			let kind: MesonTaskDefinition = {
+				type: 'meson',
+				task: taskName
+			};
+			let task = new vscode.Task(kind, taskName, 'meson', new vscode.ShellExecution("ninja", {cwd: _dir+"/.meson"}));
+			task.group = vscode.TaskGroup.Build;
+			result.push(task);
+		}
+		return result;
+	} catch (err) {
+		let channel = getOutputChannel();
+		if (err.stderr) {
+			channel.appendLine(err.stderr);
+		}
+		if (err.stdout) {
+			channel.appendLine(err.stdout);
+		}
+		channel.appendLine('Auto detecting meson task failed.');
+		channel.show(true);
+		return emptyTasks;
+	}
+}
+
+let _channel: vscode.OutputChannel;
+function getOutputChannel(): vscode.OutputChannel {
+	if (!_channel) {
+		_channel = vscode.window.createOutputChannel('Meson Auto Detection');
+	}
+	return _channel;
+}
+
+/*
+const buildNames: string[] = ['build', 'compile', 'watch'];
+function isBuildTask(name: string): boolean {
+	for (let buildName of buildNames) {
+		if (name.indexOf(buildName) !== -1) {
+			return true;
+		}
+	}
+	return false;
+}
+
+const testNames: string[] = ['test'];
+function isTestTask(name: string): boolean {
+	for (let testName of testNames) {
+		if (name.indexOf(testName) !== -1) {
+			return true;
+		}
+	}
+	return false;
+}
+*/

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import * as fs from 'fs';
+import * as cp from 'child_process';
+
+export function exists(file: string): Promise<boolean> {
+	return new Promise<boolean>((resolve, _reject) => {
+		fs.exists(file, (value) => {
+			resolve(value);
+		});
+	});
+}
+
+export function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
+	return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+		cp.exec(command, options, (error, stdout, stderr) => {
+			if (error) {
+				reject({ error, stdout, stderr });
+			}
+			resolve({ stdout, stderr });
+		});
+	});
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"lib": [
+			"es6"
+		],
+		"sourceMap": true,
+		"rootDir": "."
+	},
+	"exclude": [
+		"node_modules",
+		".vscode-test"
+	]
+}


### PR DESCRIPTION
This pull request implements the following features:
- Detects `meson.build` and automatically create a task

Based on: [task-provider-sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample) from Microsoft