### PR TITLE
Remove layout=flat from default options

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,7 @@
         "mesonbuild.configureOptions": {
           "type": "array",
           "default": [
-            "--buildtype=debug",
-            "--layout=flat"
+            "--buildtype=debug"
           ],
           "description": "Specify the list of configuration options used for Meson configuration."
         }


### PR DESCRIPTION
Flat is barely supported, and doesn't work in a lot of cases. It should
absolutely not be set by default.