### PR TITLE
change default build folder to builddir

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         },
         "mesonbuild.buildFolder": {
           "type": "string",
-          "default": "build",
+          "default": "builddir",
           "description": "Specify in which folder Meson build configure and build the project."
         },
         "mesonbuild.configureOptions": {


### PR DESCRIPTION
Upstream meson promotes to use `builddir` instead of `build`, see [this commit](https://github.com/mesonbuild/meson/commit/f3be687cbbfd1ff25c7ec4ffe8ba4adfee9a6579). This extension should follow that recommendation for the default build directory.