### PR TITLE
Apply recent changes from upstream source

### DIFF
--- a/syntaxes/meson.tmLanguage.json
+++ b/syntaxes/meson.tmLanguage.json
@@ -64,7 +64,7 @@
 			"name": "keyword.operator.arithmetic.meson"
 		},
 		{
-			"match": "(?x)\\b(add_global_arguments|add_project_arguments|add_global_link_arguments|add_project_link_arguments|add_test_setup|add_languages|assert|benchmark|build_target|configuration_data|configure_file|custom_target|declare_dependency|dependency|environment|error|executable|generator|gettext|get_option|get_variable|files|find_library|find_program|include_directories|import|install_data|install_headers|install_man|install_subdir|is_variable|jar|join_paths|library|message|option|project|run_target|run_command|set_variable|subdir|subproject|shared_library|shared_module|static_library|test|vcs_tag\n)\\b\\s*(?=\\()",
+			"match": "(?x)\\b(add_global_arguments|add_project_arguments|add_global_link_arguments|add_project_link_arguments|add_test_setup|add_languages|alias_target|assert|benchmark|both_libraries|build_target|configuration_data|configure_file|custom_target|declare_dependency|dependency|disabler|environment|error|executable|generator|gettext|get_option|get_variable|files|find_library|find_program|include_directories|import|install_data|install_headers|install_man|install_subdir|is_disabler|is_variable|jar|join_paths|library|message|option|project|run_target|run_command|set_variable|subdir|subdir_done|subproject|summary|shared_library|shared_module|static_library|test|vcs_tag|warning\n)\\b\\s*(?=\\()",
 			"name": "support.function.builtin.meson"
 		}
 	],


### PR DESCRIPTION
Add new meson functions to the syntax highlighting, as applied to upstream repository to fix https://github.com/asabil/vscode-meson/issues/14