### PR TITLE
Allow all path setting to have multiple elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,12 +184,34 @@
           "description": "Specify the list of options used for running benchmarks. --benchmark is implicit."
         },
         "mesonbuild.mesonPath": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ],
           "default": "meson",
           "description": "Specify the meson executable to use"
         },
         "mesonbuild.muonPath": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ],
           "default": "muon",
           "description": "Specify the muon executable to use"
         },
@@ -273,7 +295,18 @@
           "description": "Select which language server to use. Swift-MesonLSP is a legacy alias for mesonlsp."
         },
         "mesonbuild.languageServerPath": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ],
           "description": "Binary name or path to language server",
           "default": ""
         },

--- a/src/lsp/common.ts
+++ b/src/lsp/common.ts
@@ -33,7 +33,7 @@ export async function createLanguageServerClient(
     return null;
   }
 
-  let languageServerPath = LanguageServerClient.resolveLanguageServerPath(server, context);
+  let [languageServerPath, args] = LanguageServerClient.resolveLanguageServerPath(server, context);
   if (languageServerPath === null) {
     if (klass.artifact() == null) {
       enum Options {
@@ -60,5 +60,5 @@ export async function createLanguageServerClient(
     }
   }
 
-  return new klass(languageServerPath, context, klass.version);
+  return new klass(languageServerPath, args, context, klass.version);
 }

--- a/src/lsp/index.ts
+++ b/src/lsp/index.ts
@@ -16,8 +16,9 @@ import {
   TransportKind,
 } from "vscode-languageclient/node.js";
 import * as storage from "../storage.js";
-import { LanguageServer } from "../types.js";
+import { ExtensionConfiguration, LanguageServer } from "../types.js";
 import { serverToClass } from "./common.js";
+import { extensionConfiguration, resolveCommandAndArgs } from "../utils.js";
 
 export abstract class LanguageServerClient {
   private static readonly clientOptions: LanguageClientOptions = {
@@ -27,6 +28,7 @@ export abstract class LanguageServerClient {
   private readonly context: vscode.ExtensionContext;
 
   protected languageServerPath: vscode.Uri | null;
+  protected extraArgs: string[];
   protected referenceVersion: string;
   readonly server: LanguageServer;
 
@@ -40,11 +42,13 @@ export abstract class LanguageServerClient {
   protected constructor(
     server: LanguageServer,
     languageServerPath: vscode.Uri,
+    extraArgs: string[],
     context: vscode.ExtensionContext,
     referenceVersion: string,
   ) {
     this.server = server;
     this.languageServerPath = languageServerPath;
+    this.extraArgs = extraArgs;
     this.context = context;
     this.referenceVersion = referenceVersion;
   }
@@ -146,25 +150,26 @@ export abstract class LanguageServerClient {
     return uri;
   }
 
-  static resolveLanguageServerPath(server: LanguageServer, context: vscode.ExtensionContext): vscode.Uri | null {
-    const config = vscode.workspace.getConfiguration("mesonbuild");
-
-    const configLanguageServerPath = config["languageServerPath"];
-    if (configLanguageServerPath !== null && configLanguageServerPath != "") {
+  static resolveLanguageServerPath(
+    server: LanguageServer,
+    context: vscode.ExtensionContext,
+  ): [vscode.Uri | null, string[]] {
+    const [configLanguageServerPath, args] = resolveCommandAndArgs(extensionConfiguration("languageServerPath"));
+    if (configLanguageServerPath !== null && configLanguageServerPath !== "") {
       if (!path.isAbsolute(configLanguageServerPath)) {
         const binary = which.sync(configLanguageServerPath, { nothrow: true });
-        if (binary !== null) return vscode.Uri.from({ scheme: "file", path: binary });
+        if (binary !== null) return [vscode.Uri.from({ scheme: "file", path: binary }), args];
       }
-      return vscode.Uri.from({ scheme: "file", path: configLanguageServerPath });
+      return [vscode.Uri.from({ scheme: "file", path: configLanguageServerPath }), args];
     }
 
     const cached = LanguageServerClient.cachedLanguageServer(server, context);
-    if (cached !== null) return cached;
+    if (cached !== null) return [cached, args];
 
     const binary = which.sync(server!, { nothrow: true });
-    if (binary !== null) return vscode.Uri.from({ scheme: "file", path: binary });
+    if (binary !== null) return [vscode.Uri.from({ scheme: "file", path: binary }), args];
 
-    return null;
+    return [null, args];
   }
 
   protected static supportsSystem(): boolean {
@@ -184,7 +189,10 @@ export abstract class LanguageServerClient {
 
   async restart(): Promise<void> {
     await this.dispose();
-    this.languageServerPath = LanguageServerClient.resolveLanguageServerPath(this.server, this.context);
+    [this.languageServerPath, this.extraArgs] = LanguageServerClient.resolveLanguageServerPath(
+      this.server,
+      this.context,
+    );
     if (this.languageServerPath === null) {
       vscode.window.showErrorMessage(
         "Failed to restart the language server because a binary was not found and could not be downloaded",
@@ -201,7 +209,7 @@ export abstract class LanguageServerClient {
       transport: TransportKind.stdio,
     };
     const options = LanguageServerClient.clientOptions;
-    options.initializationOptions = vscode.workspace.getConfiguration(`mesonbuild.${this.server}`);
+    options.initializationOptions = extensionConfiguration(this.server as keyof ExtensionConfiguration);
     this.ls = new LanguageClient(
       "mesonbuild",
       `Meson Language Server (${this.server})`,
@@ -213,7 +221,7 @@ export abstract class LanguageServerClient {
   }
 
   async reloadConfig(): Promise<void> {
-    const config = vscode.workspace.getConfiguration(`mesonbuild.${this.server}`);
+    const config = extensionConfiguration(this.server as keyof ExtensionConfiguration);
     const params: DidChangeConfigurationParams = {
       settings: config,
     };

--- a/src/lsp/mesonlsp.ts
+++ b/src/lsp/mesonlsp.ts
@@ -35,19 +35,24 @@ export class MesonLSPLanguageClient extends LanguageServerClient {
   get runExe(): Executable {
     return {
       command: this.languageServerPath!.fsPath,
-      args: ["--lsp"],
+      args: [...this.extraArgs, "--lsp"],
     };
   }
 
   get debugExe(): Executable {
     return {
       command: this.languageServerPath!.fsPath,
-      args: ["--lsp"],
+      args: [...this.extraArgs, "--lsp"],
     };
   }
 
-  constructor(languageServerPath: vscode.Uri, context: vscode.ExtensionContext, referenceVersion: string) {
-    super("mesonlsp", languageServerPath, context, referenceVersion);
+  constructor(
+    languageServerPath: vscode.Uri,
+    extraArgs: string[],
+    context: vscode.ExtensionContext,
+    referenceVersion: string,
+  ) {
+    super("mesonlsp", languageServerPath, extraArgs, context, referenceVersion);
   }
 
   static override artifact(): { url: string; hash: string } | null {

--- a/src/lsp/muon.ts
+++ b/src/lsp/muon.ts
@@ -7,18 +7,23 @@ export class MuonLanguageClient extends LanguageServerClient {
   get runExe(): Executable {
     return {
       command: this.languageServerPath!.fsPath,
-      args: ["analyze", "lsp"],
+      args: [...this.extraArgs, "analyze", "lsp"],
     };
   }
 
   get debugExe(): Executable {
     return {
       command: this.languageServerPath!.fsPath,
-      args: ["analyze", "lsp"],
+      args: [...this.extraArgs, "analyze", "lsp"],
     };
   }
 
-  constructor(languageServerPath: vscode.Uri, context: vscode.ExtensionContext, referenceVersion: string) {
-    super("muon", languageServerPath, context, referenceVersion);
+  constructor(
+    languageServerPath: vscode.Uri,
+    extraArgs: string[],
+    context: vscode.ExtensionContext,
+    referenceVersion: string,
+  ) {
+    super("muon", languageServerPath, extraArgs, context, referenceVersion);
   }
 }

--- a/src/tools/meson.ts
+++ b/src/tools/meson.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { execFeed, extensionConfiguration, getOutputChannel, mesonProgram } from "../utils.js";
+import { execFeed, extensionConfiguration, getOutputChannel } from "../utils.js";
 import { Tool, CheckResult } from "../types.js";
 import { getMesonVersion } from "../introspection.js";
 import { Version } from "../version.js";
@@ -52,8 +52,6 @@ const formattingWithStdinSupportedSinceVersion = new Version([1, 7, 0]);
 const formattingWithFileNameArgumentSinceVersion = new Version([1, 9, 0]);
 
 export async function check(): Promise<CheckResult<MesonTool>> {
-  const meson_path = mesonProgram();
-
   let mesonVersion;
   try {
     mesonVersion = await getMesonVersion();
@@ -84,5 +82,9 @@ export async function check(): Promise<CheckResult<MesonTool>> {
     supportsFileNameArgument,
   };
 
-  return CheckResult.newData<MesonTool>({ path: meson_path, version: mesonVersion, options });
+  return CheckResult.newData<MesonTool>({
+    path: extensionConfiguration("mesonPath"),
+    version: mesonVersion,
+    options: options,
+  });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { Version } from "./version.js";
 
 type Dict<T> = { [x: string]: T };
 
-export type Tool<Options> = { path: string; version: Version; options: Options };
+export type Tool<Options> = { path: string[]; version: Version; options: Options };
 
 export type CheckSuccessResult<Data> = {
   data: Data;
@@ -75,8 +75,8 @@ export interface ExtensionConfiguration {
   testJobs: number;
   benchmarkOptions: string[];
   buildFolder: string;
-  mesonPath: string;
-  muonPath: string;
+  mesonPath: string[];
+  muonPath: string[];
   linting: { enabled: boolean };
   linter: {
     muon: LinterConfiguration;
@@ -90,7 +90,7 @@ export interface ExtensionConfiguration {
   debuggerExtension: "cpptools" | "vscode-lldb" | "lldb-dap" | "auto";
   debugOptions: object;
   languageServer: LanguageServer;
-  languageServerPath: string;
+  languageServerPath: string[];
   downloadLanguageServer: boolean | "ask";
   selectRootDir: boolean;
   modifySettings: boolean | ModifiableExtension[];


### PR DESCRIPTION
## Motivation

To fully support `muon` as an alternative meson implementation.  This extension invokes $meson assuming it is meson, but muon has a different CLI with different subcommands and flags.  For compatibility, muon has a subcommand `meson` that translates any meson CLI syntax into the equivalent muon CLI syntax.  Thus something like `muon meson setup --prefix=foo build` would get translated to `muon setup -Dprefix=foo build`.  To make this seamless in vscode-meson, I think the best solution is to allow settings like `mesonPath` to support multiple values.  You can work around this today by creating a wrapper script, but that shouldn't be needed.  By supporting multiple values in mesonPath you also enable other use-cases such as specifying the python interpreter to use.

While I was at it, I also implemented substitution of ${workspaceDirectory} in all string settings values.  This is particularly handy if you bundle your build tools with your project:
```
	"mesonbuild.languageServerPath": "${workspaceFolder}/Tools/bin/muon",
	"mesonbuild.mesonPath": ["${workspaceFolder}/Tools/bin/muon", "meson"],
```