### PR TITLE
Migrate to ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/mesonbuild/vscode-meson/issues"
   },
   "homepage": "https://github.com/mesonbuild/vscode-meson/blob/master/README.md",
+  "type": "module",
   "engines": {
     "vscode": "^1.101.0"
   },
@@ -46,7 +47,7 @@
     "onDebugDynamicConfigurations:cppdbg",
     "onDebugDynamicConfigurations:lldb"
   ],
-  "main": "./out/extension",
+  "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {

--- a/src/cpptoolsconfigprovider.ts
+++ b/src/cpptoolsconfigprovider.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
 import * as cpptools from "vscode-cpptools";
-import { getMesonBuildOptions, getMesonCompilers, getMesonDependencies } from "./introspection";
-import { getOutputChannel } from "./utils";
-import { Compiler, Dependencies } from "./types";
+import { getMesonBuildOptions, getMesonCompilers, getMesonDependencies } from "./introspection.js";
+import { getOutputChannel } from "./utils.js";
+import { Compiler, Dependencies } from "./types.js";
 
 export class CpptoolsProvider implements cpptools.CustomConfigurationProvider {
   cppToolsAPI?: cpptools.CppToolsApi;

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,9 +1,9 @@
 import * as os from "os";
 import * as vscode from "vscode";
 import * as path from "path";
-import { getMesonTargets } from "../introspection";
-import { Target } from "../types";
-import { extensionConfiguration, getTargetName } from "../utils";
+import { getMesonTargets } from "../introspection.js";
+import { Target } from "../types.js";
+import { extensionConfiguration, getTargetName } from "../utils.js";
 
 export enum DebuggerType {
   cppvsdbg = "cppvsdbg",

--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { extensionConfiguration, extensionConfigurationSet } from "./utils";
-import { SettingsKey } from "./types";
+import { extensionConfiguration, extensionConfigurationSet } from "./utils.js";
+import { SettingsKey } from "./types.js";
 
 export async function askConfigureOnOpen(): Promise<boolean> {
   const configureOnOpen = extensionConfiguration(SettingsKey.configureOnOpen);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
 import * as os from "os";
 import * as vscode from "vscode";
-import { getMesonTasks, getTasks, runTask, runFirstTask } from "./tasks";
-import { MesonProjectExplorer } from "./treeview";
-import { TargetNode } from "./treeview/nodes/targets";
+import { getMesonTasks, getTasks, runTask, runFirstTask } from "./tasks.js";
+import { MesonProjectExplorer } from "./treeview/index.js";
+import { TargetNode } from "./treeview/nodes/targets.js";
 import {
   extensionConfiguration,
   genEnvFile,
@@ -13,16 +13,16 @@ import {
   whenFileExists,
   mesonRootDirs,
   shouldModifySetting,
-} from "./utils";
-import { MesonDebugConfigurationProvider, DebuggerType } from "./debug/index";
-import { CpptoolsProvider, registerCppToolsProvider } from "./cpptoolsconfigprovider";
-import { testDebugHandler, testRunHandler, regenerateTests } from "./tests";
-import { activateLinters } from "./linters";
-import { activateFormatters } from "./formatters";
-import { SettingsKey, TaskQuickPickItem } from "./types";
-import { createLanguageServerClient } from "./lsp/common";
-import { askShouldDownloadLanguageServer, askConfigureOnOpen, askAndSelectRootDir, selectRootDir } from "./dialogs";
-import { getIntrospectionFile } from "./introspection";
+} from "./utils.js";
+import { MesonDebugConfigurationProvider, DebuggerType } from "./debug/index.js";
+import { CpptoolsProvider, registerCppToolsProvider } from "./cpptoolsconfigprovider.js";
+import { testDebugHandler, testRunHandler, regenerateTests } from "./tests.js";
+import { activateLinters } from "./linters.js";
+import { activateFormatters } from "./formatters.js";
+import { SettingsKey, TaskQuickPickItem } from "./types.js";
+import { createLanguageServerClient } from "./lsp/common.js";
+import { askShouldDownloadLanguageServer, askConfigureOnOpen, askAndSelectRootDir, selectRootDir } from "./dialogs.js";
+import { getIntrospectionFile } from "./introspection.js";
 
 export let extensionPath: string;
 export let workspaceState: vscode.Memento;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { extensionConfiguration, getOutputChannel } from "./utils";
-import { ToolCheckFunc, Tool, type FormattingProvider } from "./types";
-import * as muon from "./tools/muon";
-import * as meson from "./tools/meson";
+import { extensionConfiguration, getOutputChannel } from "./utils.js";
+import { ToolCheckFunc, Tool, type FormattingProvider } from "./types.js";
+import * as muon from "./tools/muon.js";
+import * as meson from "./tools/meson.js";
 
 type FormatterFunc = (tool: Tool, root: string, document: vscode.TextDocument) => Promise<vscode.TextEdit[]>;
 

--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
-import { exec, extensionConfiguration, parseJSONFileIfExists, getOutputChannel } from "./utils";
-import { Targets, Dependencies, BuildOptions, Tests, ProjectInfo, Compilers } from "./types";
-import { type VersionArray, Version } from "./version";
+import { exec, extensionConfiguration, parseJSONFileIfExists, getOutputChannel } from "./utils.js";
+import { Targets, Dependencies, BuildOptions, Tests, ProjectInfo, Compilers } from "./types.js";
+import { type VersionArray, Version } from "./version.js";
 
 export function getIntrospectionFile(buildDir: string, filename: string) {
   return path.join(buildDir, path.join("meson-info", filename));

--- a/src/linters.ts
+++ b/src/linters.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { extensionConfiguration, getOutputChannel } from "./utils";
-import { ExtensionConfiguration, LinterConfiguration, ToolCheckFunc, Tool } from "./types";
-import * as muon from "./tools/muon";
+import { extensionConfiguration, getOutputChannel } from "./utils.js";
+import { ExtensionConfiguration, LinterConfiguration, ToolCheckFunc, Tool } from "./types.js";
+import * as muon from "./tools/muon.js";
 
 type LinterFunc = (tool: Tool, sourceRoot: string, document: vscode.TextDocument) => Promise<vscode.Diagnostic[]>;
 

--- a/src/lsp/common.ts
+++ b/src/lsp/common.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { LanguageServerClient } from ".";
-import { LanguageServer } from "../types";
-import { MesonLSPLanguageClient } from "./mesonlsp";
+import { LanguageServerClient } from "./index.js";
+import { LanguageServer } from "../types.js";
+import { MesonLSPLanguageClient } from "./mesonlsp.js";
 import { Uri } from "vscode";
 
 export function serverToClass(server: LanguageServer): any {

--- a/src/lsp/index.ts
+++ b/src/lsp/index.ts
@@ -1,4 +1,4 @@
-import * as Admzip from "adm-zip";
+import Admzip from "adm-zip";
 import * as which from "which";
 import * as https from "https";
 import * as crypto from "crypto";
@@ -14,10 +14,10 @@ import {
   LanguageClientOptions,
   ServerOptions,
   TransportKind,
-} from "vscode-languageclient/node";
-import * as storage from "../storage";
-import { LanguageServer } from "../types";
-import { serverToClass } from "./common";
+} from "vscode-languageclient/node.js";
+import * as storage from "../storage.js";
+import { LanguageServer } from "../types.js";
+import { serverToClass } from "./common.js";
 
 export abstract class LanguageServerClient {
   private static readonly clientOptions: LanguageClientOptions = {

--- a/src/lsp/mesonlsp.ts
+++ b/src/lsp/mesonlsp.ts
@@ -1,8 +1,8 @@
 import * as os from "os";
 import * as vscode from "vscode";
 
-import { Executable } from "vscode-languageclient/node";
-import { LanguageServerClient } from "../lsp";
+import { Executable } from "vscode-languageclient/node.js";
+import { LanguageServerClient } from "../lsp/index.js";
 
 export class MesonLSPLanguageClient extends LanguageServerClient {
   private static artifacts: { [key: string]: { name: string; hash: string } } = {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,9 +1,9 @@
 import * as vscode from "vscode";
-import { getMesonTargets, getMesonTests, getMesonBenchmarks } from "./introspection";
-import { extensionConfiguration, getOutputChannel, getTargetName } from "./utils";
-import { Test, Target } from "./types";
-import { checkMesonIsConfigured } from "./utils";
-import { mesonProgram } from "./utils";
+import { getMesonTargets, getMesonTests, getMesonBenchmarks } from "./introspection.js";
+import { extensionConfiguration, getOutputChannel, getTargetName } from "./utils.js";
+import { Test, Target } from "./types.js";
+import { checkMesonIsConfigured } from "./utils.js";
+import { mesonProgram } from "./utils.js";
 
 interface MesonTaskDefinition extends vscode.TaskDefinition {
   type: "meson";

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,9 +1,9 @@
 import * as os from "os";
 import * as vscode from "vscode";
-import { ExecResult, exec, extensionConfiguration, getTargetName } from "./utils";
-import { Target, Targets, Test, Tests, DebugEnvironmentConfiguration } from "./types";
-import { getMesonTests, getMesonTargets } from "./introspection";
-import { workspaceState } from "./extension";
+import { ExecResult, exec, extensionConfiguration, getTargetName } from "./utils.js";
+import { Target, Targets, Test, Tests, DebugEnvironmentConfiguration } from "./types.js";
+import { getMesonTests, getMesonTargets } from "./introspection.js";
+import { workspaceState } from "./extension.js";
 
 // This is far from complete, but should suffice for the
 // "test is made of a single executable is made of a single source file" usecase.

--- a/src/tools/meson.ts
+++ b/src/tools/meson.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { execFeed, extensionConfiguration, getOutputChannel, mesonProgram } from "../utils";
-import { Tool, ToolCheckResult } from "../types";
-import { getMesonVersion } from "../introspection";
-import { Version } from "../version";
+import { execFeed, extensionConfiguration, getOutputChannel, mesonProgram } from "../utils.js";
+import { Tool, ToolCheckResult } from "../types.js";
+import { getMesonVersion } from "../introspection.js";
+import { Version } from "../version.js";
 
 export async function format(meson: Tool, root: string, document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
   const originalDocumentText = document.getText();

--- a/src/tools/muon.ts
+++ b/src/tools/muon.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { ExecResult, exec, execFeed, extensionConfiguration, getOutputChannel } from "../utils";
-import { Tool, ToolCheckResult } from "../types";
-import { Version, type VersionArray } from "../version";
+import { ExecResult, exec, execFeed, extensionConfiguration, getOutputChannel } from "../utils.js";
+import { Tool, ToolCheckResult } from "../types.js";
+import { Version, type VersionArray } from "../version.js";
 
 export async function lint(muon: Tool, root: string, document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
   const { stdout, stderr } = await execFeed(

--- a/src/treeview/basenode.ts
+++ b/src/treeview/basenode.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { hash } from "../utils";
+import { hash } from "../utils.js";
 
 export abstract class BaseNode {
   constructor(protected readonly id: string) {}

--- a/src/treeview/index.ts
+++ b/src/treeview/index.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
-import { BaseNode } from "./basenode";
-import { getMesonProjectInfo } from "../introspection";
-import { ProjectNode } from "./nodes/toplevel";
+import { BaseNode } from "./basenode.js";
+import { getMesonProjectInfo } from "../introspection.js";
+import { ProjectNode } from "./nodes/toplevel.js";
 
 class MesonProjectDataProvider implements vscode.TreeDataProvider<BaseNode> {
   private readonly _onDataChangeEmitter = new vscode.EventEmitter<BaseNode | void>();

--- a/src/treeview/nodes/base.ts
+++ b/src/treeview/nodes/base.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { isThenable } from "../../utils";
-import { BaseNode } from "../basenode";
+import { isThenable } from "../../utils.js";
+import { BaseNode } from "../basenode.js";
 
 type FolderMap<T> = Map<string, T[]>;
 

--- a/src/treeview/nodes/sources.ts
+++ b/src/treeview/nodes/sources.ts
@@ -1,9 +1,9 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { extensionRelative } from "../../utils";
-import { BaseNode } from "../basenode";
-import { BaseDirectoryNode } from "./base";
+import { extensionRelative } from "../../utils.js";
+import { BaseNode } from "../basenode.js";
+import { BaseDirectoryNode } from "./base.js";
 
 abstract class BaseFileDirectoryNode extends BaseDirectoryNode<string> {
   override async getChildren() {

--- a/src/treeview/nodes/targets.ts
+++ b/src/treeview/nodes/targets.ts
@@ -1,11 +1,11 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { BaseNode } from "../basenode";
-import { Target, Targets } from "../../types";
-import { TargetSourcesRootNode, TargetGeneratedSourcesRootNode } from "./sources";
-import { extensionRelative, getTargetName } from "../../utils";
-import { BaseDirectoryNode } from "./base";
+import { BaseNode } from "../basenode.js";
+import { Target, Targets } from "../../types.js";
+import { TargetSourcesRootNode, TargetGeneratedSourcesRootNode } from "./sources.js";
+import { extensionRelative, getTargetName } from "../../utils.js";
+import { BaseDirectoryNode } from "./base.js";
 
 export class TargetDirectoryNode extends BaseDirectoryNode<Target> {
   constructor(parentId: string, folder: string, targets: Targets) {

--- a/src/treeview/nodes/tests.ts
+++ b/src/treeview/nodes/tests.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
 
-import { BaseNode } from "../basenode";
-import { Test, Tests } from "../../types";
-import { extensionRelative } from "../../utils";
+import { BaseNode } from "../basenode.js";
+import { Test, Tests } from "../../types.js";
+import { extensionRelative } from "../../utils.js";
 
 export class TestRootNode extends BaseNode {
   constructor(

--- a/src/treeview/nodes/toplevel.ts
+++ b/src/treeview/nodes/toplevel.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 
-import { BaseNode } from "../basenode";
-import { ProjectInfo, Subproject, Targets, Tests } from "../../types";
-import { extensionRelative } from "../../utils";
-import { TargetDirectoryNode } from "./targets";
-import { getMesonBenchmarks, getMesonTargets, getMesonTests } from "../../introspection";
-import { TestRootNode } from "./tests";
+import { BaseNode } from "../basenode.js";
+import { ProjectInfo, Subproject, Targets, Tests } from "../../types.js";
+import { extensionRelative } from "../../utils.js";
+import { TargetDirectoryNode } from "./targets.js";
+import { getMesonBenchmarks, getMesonTargets, getMesonTests } from "../../introspection.js";
+import { TestRootNode } from "./tests.js";
 
 export class ProjectNode extends BaseNode {
   constructor(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import type { Version } from "./version";
+import type { Version } from "./version.js";
 
 type Dict<T> = { [x: string]: T };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as cp from "child_process";
 import * as vscode from "vscode";
-import * as which from "which";
+import which from "which";
 
 import { createHash, BinaryLike } from "crypto";
 import {
@@ -12,9 +12,9 @@ import {
   ModifiableExtension,
   type ToolCheckResult,
   type ToolCheckErrorResult,
-} from "./types";
-import { getMesonBuildOptions } from "./introspection";
-import { extensionPath, workspaceState } from "./extension";
+} from "./types.js";
+import { getMesonBuildOptions } from "./introspection.js";
+import { extensionPath, workspaceState } from "./extension.js";
 
 export interface ExecResult {
   stdout: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES2020",
+    "module": "node16",
+    "target": "es2020",
+    "moduleResolution": "node16",
     "outDir": "out",
     "lib": ["ES2020"],
     "sourceMap": true,


### PR DESCRIPTION
This should slightly improve load times, and is generally considered "the way forward".
ESM was added in 1.100, node 22 in 1.101 - so settle on that one. vscode 1.101 is 6 months old at the time of writing.