### PR TITLE
Tweak 2 options in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
         "mesonbuild.linting.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Globally enable/disable linting"
+          "description": "Globally enable/disable linting. This option won't have any effect if a language server is found"
         },
         "mesonbuild.linter.muon.enabled": {
           "type": "boolean",
@@ -227,8 +227,8 @@
         },
         "mesonbuild.formatting.enabled": {
           "type": "boolean",
-          "default": false,
-          "description": "Globally enable/disable formatting"
+          "default": true,
+          "description": "Globally enable/disable formatting. This option won't have any effect if a language server is found"
         },
         "mesonbuild.formatting.provider": {
           "type": "string",


### PR DESCRIPTION
Both `mesonbuild.formatting.enabled` and `mesonbuild.linting.enabled` are ignored when a language server is found. For some reason `mesonbuild.formatting.enabled` is also false by default, I don't understand why. Recently I had a situation where I got so confused that I went on to investigate, thinking there was a bug in this extension's code, only to find out that it was just the option being false by default.
